### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 This is the updated MCP server for [LSD](https://lsd.so). The reason behind this update is to effectively leverage dynamic tools that are defined as [trips](https://lsd.so/docs/database/language/types/keywords/according) using [our SDK](https://github.com/lsd-so/internetdata).
 
+<a href="https://glama.ai/mcp/servers/@lsd-so/internetdata-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@lsd-so/internetdata-mcp/badge" alt="LSD Server MCP server" />
+</a>
+
 ## Contents
 
 * [Getting started](#getting-started)


### PR DESCRIPTION
This PR adds a badge for the [LSD MCP Server](https://glama.ai/mcp/servers/@lsd-so/internetdata-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@lsd-so/internetdata-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@lsd-so/internetdata-mcp/badge" alt="LSD Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.